### PR TITLE
Remove whitespace in contact content textarea

### DIFF
--- a/tpl/form/contact.html.twig
+++ b/tpl/form/contact.html.twig
@@ -68,7 +68,7 @@
                 id="c_message"
                 class="form-control"
                 {% if contactFormFields.message.isRequired %} required{% endif %}
-            >{{~ oView.getContactMessage() ~}}</textarea>
+            >{{~ oView.getContactMessage()|raw ~}}</textarea>
             <label class="{% if contactFormFields.message.isRequired %}req {% endif %}" for="c_message">
                 {{ translate({ ident: "MESSAGE" }) }}
             </label>

--- a/tpl/form/contact.html.twig
+++ b/tpl/form/contact.html.twig
@@ -68,7 +68,7 @@
                 id="c_message"
                 class="form-control"
                 {% if contactFormFields.message.isRequired %} required{% endif %}
-            >{{ oView.getContactMessage() }}</textarea>
+            >{{~ oView.getContactMessage() ~}}</textarea>
             <label class="{% if contactFormFields.message.isRequired %}req {% endif %}" for="c_message">
                 {{ translate({ ident: "MESSAGE" }) }}
             </label>


### PR DESCRIPTION
(~ removes no new lines)

Before it had whitespace in the which looks somehow broken:
![grafik](https://github.com/OXID-eSales/apex-theme/assets/2500033/ceee61aa-4682-4978-91ae-c685cafb5e79)

After the change the whitespace is gone:
![grafik](https://github.com/OXID-eSales/apex-theme/assets/2500033/bd8a0116-e948-4f19-8107-edc3328cb1f3)
