### PR TITLE
Fix: Add link to shipping info on details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     - `checkout_basketcontents_basketitem_main` in `basketcontents_list.html.twig`
     - `checkout_payment` in `payment.html.twig`
     - `checkout_user` in `user.html.twig`
-    - in `order.html.twig`:
+    - in `order.html.twig` [PR-45](https://github.com/OXID-eSales/apex-theme/pull/45)
       - `checkout_order_billing_address`
       - `checkout_order_billing_address_form`
       - `checkout_order_billing_address_button`
@@ -38,6 +38,7 @@
 - Modified the broken error message when shop mode is turned to production with Setup directory still present.
 - Add same padding for "..." placeholder in paging [#0007532](https://bugs.oxid-esales.com/view.php?id=7532) [PR-41](https://github.com/OXID-eSales/apex-theme/pull/41)
 - Improve contact form message field handling [PR-42](https://github.com/OXID-eSales/apex-theme/pull/42)
-- Fixed no login request after adding a product to the favorites from the Basketlist [#0007473](https://bugs.oxid-esales.com/view.php?id=7473) 
+- Fixed no login request after adding a product to the favorites from the Basketlist [#0007473](https://bugs.oxid-esales.com/view.php?id=7473)
+- Add missing "shipping" link in the price description part [PR-43](https://github.com/OXID-eSales/apex-theme/pull/43)
 
 ## v1.0.0 - 2023-05-09

--- a/tpl/page/details/inc/productmain.html.twig
+++ b/tpl/page/details/inc/productmain.html.twig
@@ -282,15 +282,17 @@
                         {% endhasrights %}
                     {% endblock %}
 
-                    {% if oView.isVatIncluded() %}
-                        <div class="vat-info-text">
-                            {{ translate({ ident: "PLUS_SHIPPING" }) }}
-                        </div>
-                    {% else %}
-                        <div class="vat-info-text">
-                            {{ translate({ ident: "PLUS" }) }}
-                        </div>
-                    {% endif %}
+                    {% ifcontent ident "oxdeliveryinfo" set oCont %}
+                        {% if oView.isVatIncluded() %}
+                            <div class="vat-info-text">
+                                {{ translate({ ident: "PLUS_SHIPPING" }) }}<a href="{{ oCont.getLink() }}">{{ translate({ ident: "PLUS_SHIPPING2" }) }}</a>
+                            </div>
+                        {% else %}
+                            <div class="vat-info-text">
+                                {{ translate({ ident: "PLUS" }) }}<a href="{{ oCont.getLink() }}">{{ translate({ ident: "PLUS_SHIPPING2" }) }}</a>
+                            </div>
+                        {% endif %}
+                    {% endifcontent %}
                 </div>
 
                 {% if oDetailsProduct.loadAmountPriceInfo() %}


### PR DESCRIPTION
In the template file productmain.html.twig the "shipping" part is missing in the "isVatIncluded" section.

The result is the output: "incl. tax, plus "
This should be "incl. tax, plus shipping" with linked "shipping" to the oxdeliveryinfo content page.

Without fix:
![2023-09-22_13h50_18](https://github.com/OXID-eSales/apex-theme/assets/2500033/22e98f39-c0a4-43f6-a9bb-9f0f5cd6e8c0)

With fix:
![2023-09-22_13h50_33](https://github.com/OXID-eSales/apex-theme/assets/2500033/a06f07f1-ac62-43bf-94ce-fbdce4ce031a)
