### PR TITLE
Payment block optimize

### DIFF
--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -76,7 +76,9 @@
                                                     </form>
                                                 </h4>
                                                 <div class="card-body">
-                                                    {% include "widget/address/billing_address.html.twig" %}
+                                                    {% block checkout_order_billing_address_desc %}
+                                                        {% include "widget/address/billing_address.html.twig" %}
+                                                    {% endblock %}
                                                 </div>
                                                 <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                     {{ translate({ ident: "SHIPPING_ADDRESS" }) }}
@@ -93,12 +95,14 @@
                                                     </form>
                                                 </h4>
                                                 <div class="card-body">
-                                                    {% set oDelAdress = oView.getDelAddress() %}
-                                                    {% if oDelAdress %}
-                                                        {% include "widget/address/shipping_address.html.twig" with {delivadr: oDelAdress} %}
-                                                    {% else %}
-                                                        {% include "widget/address/billing_address.html.twig" %}
-                                                    {% endif %}
+                                                    {% block checkout_order_shipping_address_desc %}
+                                                        {% set oDelAdress = oView.getDelAddress() %}
+                                                        {% if oDelAdress %}
+                                                            {% include "widget/address/shipping_address.html.twig" with {delivadr: oDelAdress} %}
+                                                        {% else %}
+                                                            {% include "widget/address/billing_address.html.twig" %}
+                                                        {% endif %}
+                                                    {% endblock %}
                                                 </div>
                                             </div>
                                         {% endblock %}
@@ -120,8 +124,10 @@
                                                 </form>
                                             </h4>
                                             <div class="card-body">
-                                                {% set oShipSet = oView.getShipSet() %}
-                                                {{ oShipSet.oxdeliveryset__oxtitle.value }}
+                                                {% block checkout_order_shipping_carrier_desc %}
+                                                    {% set oShipSet = oView.getShipSet() %}
+                                                    {{ oShipSet.oxdeliveryset__oxtitle.value }}
+                                                {% endblock %}
                                             </div>
                                             <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                 {{ translate({ ident: "PAYMENT_METHOD" }) }}
@@ -139,8 +145,10 @@
                                                 </form>
                                             </h4>
                                             <div class="card-body">
-                                                {% set payment = oView.getPayment() %}
-                                                {{ payment.oxpayments__oxdesc.value }}
+                                                {% block checkout_order_payment_method_desc %}
+                                                    {% set payment = oView.getPayment() %}
+                                                    {{ payment.oxpayments__oxdesc.value }}
+                                                {% endblock %}
                                             </div>
                                         {% endblock %}
 
@@ -161,7 +169,9 @@
                                                     </form>
                                                 </h4>
                                                 <div class="card-body">
-                                                    {{ oView.getOrderRemark()|nl2br }}
+                                                    {% block checkout_order_remark_desc %}
+                                                        {{ oView.getOrderRemark()|nl2br }}
+                                                    {% endblock %}
                                                 </div>
                                             {% endif %}
                                         {% endblock %}

--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -61,37 +61,37 @@
                                             {% endblock % #}
                                         {% block checkout_order_address %}
                                             <div id="orderAddress">
-                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                    {{ oViewConf.getHiddenSid()|raw }}
-                                                    <input type="hidden" name="cl" value="user">
-                                                    <input type="hidden" name="fnc" value="">
-                                                    <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
-                                                        {{ translate({ ident: "BILLING_ADDRESS" }) }}
+                                                <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
+                                                    {{ translate({ ident: "BILLING_ADDRESS" }) }}
+                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                        {{ oViewConf.getHiddenSid()|raw }}
+                                                        <input type="hidden" name="cl" value="user">
+                                                        <input type="hidden" name="fnc" value="">
                                                         <button type="submit" class="btn"
                                                                 title="{{ translate({ ident: "EDIT" }) }}">
                                                             <svg aria-hidden="true">
                                                                 <use xlink:href="#pencil"></use>
                                                             </svg>
                                                         </button>
-                                                    </h4>
-                                                </form>
+                                                    </form>
+                                                </h4>
                                                 <div class="card-body">
                                                     {% include "widget/address/billing_address.html.twig" %}
                                                 </div>
-                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                    {{ oViewConf.getHiddenSid()|raw }}
-                                                    <input type="hidden" name="cl" value="user">
-                                                    <input type="hidden" name="fnc" value="">
-                                                    <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
-                                                        {{ translate({ ident: "SHIPPING_ADDRESS" }) }}
+                                                <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
+                                                    {{ translate({ ident: "SHIPPING_ADDRESS" }) }}
+                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                        {{ oViewConf.getHiddenSid()|raw }}
+                                                        <input type="hidden" name="cl" value="user">
+                                                        <input type="hidden" name="fnc" value="">
                                                         <button type="submit" class="btn"
                                                                 title="{{ translate({ ident: "EDIT" }) }}">
                                                             <svg aria-hidden="true">
                                                                 <use xlink:href="#pencil"></use>
                                                             </svg>
                                                         </button>
-                                                    </h4>
-                                                </form>
+                                                    </form>
+                                                </h4>
                                                 <div class="card-body">
                                                     {% set oDelAdress = oView.getDelAddress() %}
                                                     {% if oDelAdress %}
@@ -104,40 +104,40 @@
                                         {% endblock %}
 
                                         {% block shippingAndPayment %}
-                                            <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
-                                                  id="orderShipping">
-                                                {{ oViewConf.getHiddenSid()|raw }}
-                                                <input type="hidden" name="cl" value="payment">
-                                                <input type="hidden" name="fnc" value="">
-                                                <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
-                                                    {{ translate({ ident: "SHIPPING_CARRIER" }) }}
+                                            <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
+                                                {{ translate({ ident: "SHIPPING_CARRIER" }) }}
+                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
+                                                      id="orderShipping">
+                                                    {{ oViewConf.getHiddenSid()|raw }}
+                                                    <input type="hidden" name="cl" value="payment">
+                                                    <input type="hidden" name="fnc" value="">
                                                     <button type="submit" class="btn"
                                                             title="{{ translate({ ident: "EDIT" }) }}">
                                                         <svg aria-hidden="true">
                                                             <use xlink:href="#pencil"></use>
                                                         </svg>
                                                     </button>
-                                                </h4>
-                                            </form>
+                                                </form>
+                                            </h4>
                                             <div class="card-body">
                                                 {% set oShipSet = oView.getShipSet() %}
                                                 {{ oShipSet.oxdeliveryset__oxtitle.value }}
                                             </div>
-                                            <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
-                                                  id="orderPayment">
-                                                {{ oViewConf.getHiddenSid()|raw }}
-                                                <input type="hidden" name="cl" value="payment">
-                                                <input type="hidden" name="fnc" value="">
-                                                <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
-                                                    {{ translate({ ident: "PAYMENT_METHOD" }) }}
+                                            <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
+                                                {{ translate({ ident: "PAYMENT_METHOD" }) }}
+                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
+                                                      id="orderPayment">
+                                                    {{ oViewConf.getHiddenSid()|raw }}
+                                                    <input type="hidden" name="cl" value="payment">
+                                                    <input type="hidden" name="fnc" value="">
                                                     <button type="submit" class="btn"
                                                             title="{{ translate({ ident: "EDIT" }) }}">
                                                         <svg aria-hidden="true">
                                                             <use xlink:href="#pencil"></use>
                                                         </svg>
                                                     </button>
-                                                </h4>
-                                            </form>
+                                                </form>
+                                            </h4>
                                             <div class="card-body">
                                                 {% set payment = oView.getPayment() %}
                                                 {{ payment.oxpayments__oxdesc.value }}
@@ -146,23 +146,23 @@
 
                                         {% block checkout_order_remark %}
                                             {% if oView.getOrderRemark() %}
-                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                    {{ oViewConf.getHiddenSid()|raw }}
-                                                    <input type="hidden" name="cl" value="user">
-                                                    <input type="hidden" name="fnc" value="">
-                                                    <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
-                                                        {{ translate({ ident: "WHAT_I_WANTED_TO_SAY" }) }}
+                                                <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
+                                                    {{ translate({ ident: "WHAT_I_WANTED_TO_SAY" }) }}
+                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                        {{ oViewConf.getHiddenSid()|raw }}
+                                                        <input type="hidden" name="cl" value="user">
+                                                        <input type="hidden" name="fnc" value="">
                                                         <button type="submit" class="btn"
                                                                 title="{{ translate({ ident: "EDIT" }) }}">
                                                             <svg aria-hidden="true">
                                                                 <use xlink:href="#pencil"></use>
                                                             </svg>
                                                         </button>
-                                                    </h4>
-                                                    <div class="card-body">
-                                                        {{ oView.getOrderRemark()|nl2br }}
-                                                    </div>
-                                                </form>
+                                                    </form>
+                                                </h4>
+                                                <div class="card-body">
+                                                    {{ oView.getOrderRemark()|nl2br }}
+                                                </div>
                                             {% endif %}
                                         {% endblock %}
 

--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -74,10 +74,10 @@
                                                             </svg>
                                                         </button>
                                                     </h4>
-                                                    <div class="card-body">
-                                                        {% include "widget/address/billing_address.html.twig" %}
-                                                    </div>
                                                 </form>
+                                                <div class="card-body">
+                                                    {% include "widget/address/billing_address.html.twig" %}
+                                                </div>
                                                 <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
                                                     {{ oViewConf.getHiddenSid()|raw }}
                                                     <input type="hidden" name="cl" value="user">
@@ -91,15 +91,15 @@
                                                             </svg>
                                                         </button>
                                                     </h4>
-                                                    <div class="card-body">
-                                                        {% set oDelAdress = oView.getDelAddress() %}
-                                                        {% if oDelAdress %}
-                                                            {% include "widget/address/shipping_address.html.twig" with {delivadr: oDelAdress} %}
-                                                        {% else %}
-                                                            {% include "widget/address/billing_address.html.twig" %}
-                                                        {% endif %}
-                                                    </div>
                                                 </form>
+                                                <div class="card-body">
+                                                    {% set oDelAdress = oView.getDelAddress() %}
+                                                    {% if oDelAdress %}
+                                                        {% include "widget/address/shipping_address.html.twig" with {delivadr: oDelAdress} %}
+                                                    {% else %}
+                                                        {% include "widget/address/billing_address.html.twig" %}
+                                                    {% endif %}
+                                                </div>
                                             </div>
                                         {% endblock %}
 
@@ -118,11 +118,11 @@
                                                         </svg>
                                                     </button>
                                                 </h4>
-                                                {% set oShipSet = oView.getShipSet() %}
-                                                <div class="card-body">
-                                                    {{ oShipSet.oxdeliveryset__oxtitle.value }}
-                                                </div>
                                             </form>
+                                            <div class="card-body">
+                                                {% set oShipSet = oView.getShipSet() %}
+                                                {{ oShipSet.oxdeliveryset__oxtitle.value }}
+                                            </div>
                                             <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
                                                   id="orderPayment">
                                                 {{ oViewConf.getHiddenSid()|raw }}
@@ -137,11 +137,11 @@
                                                         </svg>
                                                     </button>
                                                 </h4>
-                                                <div class="card-body">
-                                                    {% set payment = oView.getPayment() %}
-                                                    {{ payment.oxpayments__oxdesc.value }}
-                                                </div>
                                             </form>
+                                            <div class="card-body">
+                                                {% set payment = oView.getPayment() %}
+                                                {{ payment.oxpayments__oxdesc.value }}
+                                            </div>
                                         {% endblock %}
 
                                         {% block checkout_order_remark %}

--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -68,12 +68,14 @@
                                                             {{ oViewConf.getHiddenSid()|raw }}
                                                             <input type="hidden" name="cl" value="user">
                                                             <input type="hidden" name="fnc" value="">
-                                                            <button type="submit" class="btn"
-                                                                    title="{{ translate({ ident: "EDIT" }) }}">
-                                                                <svg aria-hidden="true">
-                                                                    <use xlink:href="#pencil"></use>
-                                                                </svg>
-                                                            </button>
+                                                            {% block checkout_order_billing_address_button %}
+                                                                <button type="submit" class="btn"
+                                                                        title="{{ translate({ ident: "EDIT" }) }}">
+                                                                    <svg aria-hidden="true">
+                                                                        <use xlink:href="#pencil"></use>
+                                                                    </svg>
+                                                                </button>
+                                                            {% endblock %}
                                                         </form>
                                                     {% endblock %}
                                                 </h4>
@@ -89,12 +91,14 @@
                                                             {{ oViewConf.getHiddenSid()|raw }}
                                                             <input type="hidden" name="cl" value="user">
                                                             <input type="hidden" name="fnc" value="">
-                                                            <button type="submit" class="btn"
-                                                                    title="{{ translate({ ident: "EDIT" }) }}">
-                                                                <svg aria-hidden="true">
-                                                                    <use xlink:href="#pencil"></use>
-                                                                </svg>
-                                                            </button>
+                                                            {% block checkout_order_shipping_address_button %}
+                                                                <button type="submit" class="btn"
+                                                                        title="{{ translate({ ident: "EDIT" }) }}">
+                                                                    <svg aria-hidden="true">
+                                                                        <use xlink:href="#pencil"></use>
+                                                                    </svg>
+                                                                </button>
+                                                            {% endblock %}
                                                         </form>
                                                     {% endblock %}
                                                 </h4>
@@ -120,12 +124,14 @@
                                                         {{ oViewConf.getHiddenSid()|raw }}
                                                         <input type="hidden" name="cl" value="payment">
                                                         <input type="hidden" name="fnc" value="">
-                                                        <button type="submit" class="btn"
-                                                                title="{{ translate({ ident: "EDIT" }) }}">
-                                                            <svg aria-hidden="true">
-                                                                <use xlink:href="#pencil"></use>
-                                                            </svg>
-                                                        </button>
+                                                        {% block checkout_order_shipping_carrier_button %}
+                                                            <button type="submit" class="btn"
+                                                                    title="{{ translate({ ident: "EDIT" }) }}">
+                                                                <svg aria-hidden="true">
+                                                                    <use xlink:href="#pencil"></use>
+                                                                </svg>
+                                                            </button>
+                                                        {% endblock %}
                                                     </form>
                                                 {% endblock %}
                                             </h4>
@@ -143,12 +149,14 @@
                                                         {{ oViewConf.getHiddenSid()|raw }}
                                                         <input type="hidden" name="cl" value="payment">
                                                         <input type="hidden" name="fnc" value="">
-                                                        <button type="submit" class="btn"
-                                                                title="{{ translate({ ident: "EDIT" }) }}">
-                                                            <svg aria-hidden="true">
-                                                                <use xlink:href="#pencil"></use>
-                                                            </svg>
-                                                        </button>
+                                                        {% block checkout_order_payment_method_button %}
+                                                            <button type="submit" class="btn"
+                                                                    title="{{ translate({ ident: "EDIT" }) }}">
+                                                                <svg aria-hidden="true">
+                                                                    <use xlink:href="#pencil"></use>
+                                                                </svg>
+                                                            </button>
+                                                        {% endblock %}
                                                     </form>
                                                 {% endblock %}
                                             </h4>
@@ -169,12 +177,14 @@
                                                             {{ oViewConf.getHiddenSid()|raw }}
                                                             <input type="hidden" name="cl" value="user">
                                                             <input type="hidden" name="fnc" value="">
-                                                            <button type="submit" class="btn"
-                                                                    title="{{ translate({ ident: "EDIT" }) }}">
-                                                                <svg aria-hidden="true">
-                                                                    <use xlink:href="#pencil"></use>
-                                                                </svg>
-                                                            </button>
+                                                            {% block checkout_order_remark_button %}
+                                                                <button type="submit" class="btn"
+                                                                        title="{{ translate({ ident: "EDIT" }) }}">
+                                                                    <svg aria-hidden="true">
+                                                                        <use xlink:href="#pencil"></use>
+                                                                    </svg>
+                                                                </button>
+                                                            {% endblock %}
                                                         </form>
                                                     {% endblock %}
                                                 </h4>

--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -63,17 +63,19 @@
                                             <div id="orderAddress">
                                                 <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                     {{ translate({ ident: "BILLING_ADDRESS" }) }}
-                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                        {{ oViewConf.getHiddenSid()|raw }}
-                                                        <input type="hidden" name="cl" value="user">
-                                                        <input type="hidden" name="fnc" value="">
-                                                        <button type="submit" class="btn"
-                                                                title="{{ translate({ ident: "EDIT" }) }}">
-                                                            <svg aria-hidden="true">
-                                                                <use xlink:href="#pencil"></use>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
+                                                    {% block checkout_order_billing_address_form %}
+                                                        <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                            {{ oViewConf.getHiddenSid()|raw }}
+                                                            <input type="hidden" name="cl" value="user">
+                                                            <input type="hidden" name="fnc" value="">
+                                                            <button type="submit" class="btn"
+                                                                    title="{{ translate({ ident: "EDIT" }) }}">
+                                                                <svg aria-hidden="true">
+                                                                    <use xlink:href="#pencil"></use>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    {% endblock %}
                                                 </h4>
                                                 <div class="card-body">
                                                     {% block checkout_order_billing_address_desc %}
@@ -82,17 +84,19 @@
                                                 </div>
                                                 <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                     {{ translate({ ident: "SHIPPING_ADDRESS" }) }}
-                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                        {{ oViewConf.getHiddenSid()|raw }}
-                                                        <input type="hidden" name="cl" value="user">
-                                                        <input type="hidden" name="fnc" value="">
-                                                        <button type="submit" class="btn"
-                                                                title="{{ translate({ ident: "EDIT" }) }}">
-                                                            <svg aria-hidden="true">
-                                                                <use xlink:href="#pencil"></use>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
+                                                    {% block checkout_order_shipping_address_form %}
+                                                        <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                            {{ oViewConf.getHiddenSid()|raw }}
+                                                            <input type="hidden" name="cl" value="user">
+                                                            <input type="hidden" name="fnc" value="">
+                                                            <button type="submit" class="btn"
+                                                                    title="{{ translate({ ident: "EDIT" }) }}">
+                                                                <svg aria-hidden="true">
+                                                                    <use xlink:href="#pencil"></use>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    {% endblock %}
                                                 </h4>
                                                 <div class="card-body">
                                                     {% block checkout_order_shipping_address_desc %}
@@ -110,18 +114,20 @@
                                         {% block shippingAndPayment %}
                                             <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                 {{ translate({ ident: "SHIPPING_CARRIER" }) }}
-                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
-                                                      id="orderShipping">
-                                                    {{ oViewConf.getHiddenSid()|raw }}
-                                                    <input type="hidden" name="cl" value="payment">
-                                                    <input type="hidden" name="fnc" value="">
-                                                    <button type="submit" class="btn"
-                                                            title="{{ translate({ ident: "EDIT" }) }}">
-                                                        <svg aria-hidden="true">
-                                                            <use xlink:href="#pencil"></use>
-                                                        </svg>
-                                                    </button>
-                                                </form>
+                                                {% block checkout_order_shipping_carrier_form %}
+                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
+                                                          id="orderShipping">
+                                                        {{ oViewConf.getHiddenSid()|raw }}
+                                                        <input type="hidden" name="cl" value="payment">
+                                                        <input type="hidden" name="fnc" value="">
+                                                        <button type="submit" class="btn"
+                                                                title="{{ translate({ ident: "EDIT" }) }}">
+                                                            <svg aria-hidden="true">
+                                                                <use xlink:href="#pencil"></use>
+                                                            </svg>
+                                                        </button>
+                                                    </form>
+                                                {% endblock %}
                                             </h4>
                                             <div class="card-body">
                                                 {% block checkout_order_shipping_carrier_desc %}
@@ -131,18 +137,20 @@
                                             </div>
                                             <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                 {{ translate({ ident: "PAYMENT_METHOD" }) }}
-                                                <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
-                                                      id="orderPayment">
-                                                    {{ oViewConf.getHiddenSid()|raw }}
-                                                    <input type="hidden" name="cl" value="payment">
-                                                    <input type="hidden" name="fnc" value="">
-                                                    <button type="submit" class="btn"
-                                                            title="{{ translate({ ident: "EDIT" }) }}">
-                                                        <svg aria-hidden="true">
-                                                            <use xlink:href="#pencil"></use>
-                                                        </svg>
-                                                    </button>
-                                                </form>
+                                                {% block checkout_order_payment_method_form %}
+                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post"
+                                                          id="orderPayment">
+                                                        {{ oViewConf.getHiddenSid()|raw }}
+                                                        <input type="hidden" name="cl" value="payment">
+                                                        <input type="hidden" name="fnc" value="">
+                                                        <button type="submit" class="btn"
+                                                                title="{{ translate({ ident: "EDIT" }) }}">
+                                                            <svg aria-hidden="true">
+                                                                <use xlink:href="#pencil"></use>
+                                                            </svg>
+                                                        </button>
+                                                    </form>
+                                                {% endblock %}
                                             </h4>
                                             <div class="card-body">
                                                 {% block checkout_order_payment_method_desc %}
@@ -156,17 +164,19 @@
                                             {% if oView.getOrderRemark() %}
                                                 <h4 class="card-header card-title card-header-edit d-flex justify-content-between align-items-center">
                                                     {{ translate({ ident: "WHAT_I_WANTED_TO_SAY" }) }}
-                                                    <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
-                                                        {{ oViewConf.getHiddenSid()|raw }}
-                                                        <input type="hidden" name="cl" value="user">
-                                                        <input type="hidden" name="fnc" value="">
-                                                        <button type="submit" class="btn"
-                                                                title="{{ translate({ ident: "EDIT" }) }}">
-                                                            <svg aria-hidden="true">
-                                                                <use xlink:href="#pencil"></use>
-                                                            </svg>
-                                                        </button>
-                                                    </form>
+                                                    {% block checkout_order_remark_form %}
+                                                        <form action="{{ oViewConf.getSslSelfLink()|raw }}" method="post">
+                                                            {{ oViewConf.getHiddenSid()|raw }}
+                                                            <input type="hidden" name="cl" value="user">
+                                                            <input type="hidden" name="fnc" value="">
+                                                            <button type="submit" class="btn"
+                                                                    title="{{ translate({ ident: "EDIT" }) }}">
+                                                                <svg aria-hidden="true">
+                                                                    <use xlink:href="#pencil"></use>
+                                                                </svg>
+                                                            </button>
+                                                        </form>
+                                                    {% endblock %}
                                                 </h4>
                                                 <div class="card-body">
                                                     {% block checkout_order_remark_desc %}


### PR DESCRIPTION
Hello Core-Team, I´ve changed the order-template.

Now we have more blocks to inject code from the payment-modules. This means that merchants no longer have to style the payment module templates as much or at all.