### PR TITLE
align content width of some checkout pages

### DIFF
--- a/tpl/page/checkout/order.html.twig
+++ b/tpl/page/checkout/order.html.twig
@@ -9,11 +9,11 @@
             {% include "message/error.html.twig" with {statusMessage: "ERROR_DELIVERY_ADDRESS_WAS_CHANGED_DURING_CHECKOUT"|translate} %}
         {% endif %}
     {% endblock %}
-    <div class="container-md py-5">
+    <div class="container-xxl py-5">
         <div class="row justify-content-center">
-            <div class="col-md-12 col-lg-8 col-xl-8 col-xxl-6">
+            <div class="col-md-12">
                 <div class="row">
-                    <div class="col-lg-7">
+                    <div class="col-lg-8 col-xl-9">
                         <div class="card mb-3">
                             {% block checkout_order_main %}
 
@@ -231,7 +231,7 @@
                             {% endblock %}
                         </div>
                     </div>
-                    <div class="col-lg-5">
+                    <div class="col-lg-4 col-xl-3">
                         <div class="sticky-md-top">
                             {% include "page/checkout/inc/summary_sidebar.html.twig" %}
 

--- a/tpl/page/checkout/payment.html.twig
+++ b/tpl/page/checkout/payment.html.twig
@@ -1,11 +1,11 @@
 {% capture append = "oxidBlock_content" %}
 
     {% block checkout_payment %}
-    <div class="container-md py-5">
+    <div class="container-xxl py-5">
         <div class="row justify-content-center">
-            <div class="col-md-12 col-lg-8 col-xl-8 col-xxl-6">
+            <div class="col-md-12">
                 <div class="row">
-                    <div class="col-lg-7">
+                    <div class="col-lg-8 col-xl-9">
                         <div class="card active mb-3">
                             {% block checkout_payment_main %}
                                 {% block checkout_payment_errors %}
@@ -153,7 +153,7 @@
                             {{ translate({ ident: "PREVIOUS_STEP" }) }}</a>
 
                     </div>
-                    <div class="col-lg-5">
+                    <div class="col-lg-4 col-xl-3">
                         <div class="sticky-md-top">
                             {% include "page/checkout/inc/summary_sidebar.html.twig" %}
 

--- a/tpl/page/checkout/user.html.twig
+++ b/tpl/page/checkout/user.html.twig
@@ -1,16 +1,16 @@
 {% capture append = "oxidBlock_content" %}
     {% set template_title = "" %}
     {% if not oView.getLoginOption() and not oxcmp_user %}
-        <div class="container-md py-5">
+        <div class="container-xxl py-5">
             <div class="row justify-content-center">
-                <div class="col-md-12 col-lg-8 col-xl-8 col-xxl-6">
+                <div class="col-md-12">
                     <div class="row">
-                        <div class="col-lg-7">
+                        <div class="col-lg-8 col-xl-9">
                             {% block checkout_user_main %}
                                 {% include "page/checkout/inc/options.html.twig" %}
                             {% endblock %}
                         </div>
-                        <div class="col-lg-5">
+                        <div class="col-lg-4 col-xl-3">
                             <div class="sticky-md-top">
                                 {% include "page/checkout/inc/summary_sidebar.html.twig" %}
                             </div>
@@ -21,11 +21,11 @@
         </div>
     {% else %}
         {% block checkout_user %}
-        <div class="container-md py-5">
+        <div class="container-xxl py-5">
             <div class="row justify-content-center">
-                <div class="col-md-12 col-lg-8 col-xl-8 col-xxl-6">
+                <div class="col-md-12">
                     <div class="row">
-                        <div class="col-lg-7">
+                        <div class="col-lg-8 col-xl-9">
                             <div class="card mt-n2 mb-3 active">
 
                                 {% block checkout_user_noregistration %}
@@ -68,7 +68,7 @@
                                 {{ translate({ ident: "BACK" }) }}
                             </a>
                         </div>
-                        <div class="col-lg-5">
+                        <div class="col-lg-4 col-xl-3">
                             <div class="sticky-md-top">
                                 {% include "page/checkout/inc/summary_sidebar.html.twig" %}
 


### PR DESCRIPTION
Checkout pages have different content widths on large viewports.

- Basket: 12 of 12 (xxl)
- User: 6 of 12 (xxl)
- Payment: 6 of 12 (xxl)
- Order: 6 of 12 (xxl)
- Thankyou: 12 of 12 (xxl)

A uniform look makes the checkout process more consistent and does not squash the elements together unnecessarily.