### PR TITLE
Fix block name in listitem_grid.html.twig

### DIFF
--- a/tpl/widget/product/listitem_grid.html.twig
+++ b/tpl/widget/product/listitem_grid.html.twig
@@ -117,7 +117,7 @@
 
         <div class="card-body{% if tprice and tprice.getBruttoPrice() > price.getBruttoPrice() %} sale{% endif %}">
             <div class="d-flex justify-content-between">
-                {% block widget_product_listitem_infogrid_titlebox %}
+                {% block widget_product_listitem_grid_titlebox %}
                     <div class="h5 card-title">
                         {{ product.oxarticles__oxtitle.value }} {{ product.oxarticles__oxvarselect.value }}
                     </div>


### PR DESCRIPTION
See https://bugs.oxid-esales.com/view.php?id=6429
In listitem_grid the block names should be named `..._grid_...` not `..._infogrid_...`