### PR TITLE
Raw output for newbasketitemmsg.html.twig

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -9,6 +9,7 @@
 - Allow HTML code in payment descriptions
 - RDFa templates contain escaped HTML tags
 - Template contains wrongly named block [#0006429](https://bugs.oxid-esales.com/view.php?id=6429), [PR-56](https://github.com/OXID-eSales/apex-theme/pull/56)
+- New item in basket message display [#0007548](https://bugs.oxid-esales.com/view.php?id=7548) [PR-57](https://github.com/OXID-eSales/apex-theme/pull/57)
 
 ### Removed
 - PHP v8.0 support

--- a/tpl/layout/header.html.twig
+++ b/tpl/layout/header.html.twig
@@ -159,5 +159,5 @@
     {% endif %}
 {% endblock %}
 
-{{ insert_new_basket_item({tpl: "widget/minibasket/newbasketitemmsg.html.twig", type: "message"}) }}
+{{ insert_new_basket_item({tpl: "widget/minibasket/newbasketitemmsg.html.twig", type: "message"})|raw }}
 {% include_dynamic "widget/minibasket/minibasketmodal.html.twig" %}


### PR DESCRIPTION
As widget/minibasket/newbasketitemmsg.html.twig contains html it has to be inserted with `raw` modifier.

Mentioned in bug entry 7548:  [https://bugs.oxid-esales.com/view.php?id=7548](https://bugs.oxid-esales.com/view.php?id=7548)