### PR TITLE
Fix for: breadcrumb can't access oDetailsProduct variable on detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Respect the "Display attribute's value for products in checkout" option for attributes in basket [#0007648](https://bugs.oxid-esales.com/view.php?id=7648) [PR-58](https://github.com/OXID-eSales/apex-theme/pull/58)
 - Update theme id in english theme_options.php [PR-59](https://github.com/OXID-eSales/apex-theme/pull/59)
 - Fixed copy notice list feature for firefox [PR-61](https://github.com/OXID-eSales/apex-theme/pull/61)
-- Fixed delivery address change on firefox [PR-61](https://github.com/OXID-eSales/apex-theme/pull/61)
+- Fixed delivery address change on firefox [PR-60](https://github.com/OXID-eSales/apex-theme/pull/60)
+- Fixed title in breadcrumb for product detail page [PR-62](https://github.com/OXID-eSales/apex-theme/pull/62)
 
 ## v1.3.0 - 2024-03-18
 

--- a/tpl/widget/breadcrumb.html.twig
+++ b/tpl/widget/breadcrumb.html.twig
@@ -25,9 +25,10 @@
                                     </li>
                                 {% endfor %}
                                 {% if oView.getClassKey() == "details" %}
-                                <li class="breadcrumb-item active">
-                                    {{ oDetailsProduct.oxarticles__oxtitle.value }}
-                                </li>
+                                    {% set oDetailsProduct = oView.getProduct() %}
+                                    <li class="breadcrumb-item active">
+                                        {{ oDetailsProduct.oxarticles__oxtitle.value }}
+                                    </li>
                                 {% endif %}
                             {% endblock %}
                         </ol>


### PR DESCRIPTION
Fixes bug entry 7545
[https://bugs.oxid-esales.com/view.php?id=7545](https://bugs.oxid-esales.com/view.php?id=7545)