### PR TITLE
submit on payment page don't triggers other submit events

### DIFF
--- a/tpl/page/checkout/payment.html.twig
+++ b/tpl/page/checkout/payment.html.twig
@@ -152,7 +152,7 @@
                             {% include "page/checkout/inc/summary_sidebar.html.twig" %}
 
                             <button type="button" class="btn btn-highlight btn-lg w-100"
-                                    onclick="document.getElementById('payment').submit();">
+                                    onclick="document.querySelector('#payment').requestSubmit();">
                                 {{ translate({ ident: "NEXT" }) }}
                             </button>
                         </div>


### PR DESCRIPTION
If there is a submit event registered on payment form in order step 3, it won't triggered due the current submit java script on the "next step" button.