### PR TITLE
add missing blocks for overloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log for OXID APEX Theme
 
-## v1.3.1 - Unreleased
+## v1.4.0 - Unreleased
+
+### Added
+- New blocks in `tpl/layout/base.html.twig`: base_preload_fonts, base_preload_css, base_preload_js [PR-65](https://github.com/OXID-eSales/apex-theme/pull/65)
 
 ### Fixed
 - Allow html-code in payment-descriptions

--- a/tpl/layout/base.html.twig
+++ b/tpl/layout/base.html.twig
@@ -6,10 +6,16 @@
         <meta http-equiv="Content-Type" content="text/html; charset={{ oView.getCharSet() }}">
         <link rel="dns-prefetch" href="{{ oViewConf.getBaseDir()|raw }}">
         <link rel="preconnect" href="{{ oViewConf.getBaseDir()|raw }}">
+        {% block base_preload_fonts %}
         <link rel="preload" href="{{ oViewConf.getResourceUrl('fonts/Roboto-Regular.woff2')|raw }}" as="font" crossorigin type="font/woff2">
         <link rel="preload" href="{{ oViewConf.getResourceUrl('fonts/oswald-latin-600-normal.woff2')|raw }}" as="font" crossorigin type="font/woff2">
+        {% endblock %}
+        {% block base_preload_css %}
         <link rel="preload" href="{{ oViewConf.getResourceUrl('css/styles.min.css')|raw }}" as="style">
+        {% endblock %}
+        {% block base_preload_js %}
         <link rel="preload" href="{{ oViewConf.getResourceUrl('js/scripts.min.js')|raw }}" as="script">
+        {% endblock %}
 
         {% set sPageTitle = oView.getPageTitle() %}
         <title>{% block head_title %}{{ sPageTitle }}{% endblock %}</title>


### PR DESCRIPTION
This blocks extremly important for the new custom-theme-handle-strategy of twig.
There should no longer be a child theme (like in Smarty), but all overrides should take place in one module. In order to overload APEX assets, the preload area of ​​the CSS/JS/FONTS files must be overloadable in addition to the actual loading of the CSS/JS/FONTS files.