### PR TITLE
AGB checkbox inside block

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Sanitize HTML filter for content
+- New block `agb_checkbox` in `tpl/page/checkout/inc/agb.html.twig` for easier customization by payment modules [PR-69](https://github.com/OXID-eSales/apex-theme/pull/69)
 
 ### Changed
 - Removed Bootstrap 3 CSS classes from templates
@@ -44,7 +45,7 @@
 ### Fixed
 - Product selection in basket overview page [#0007708](https://bugs.oxid-esales.com/view.php?id=7708)
 - Product selection for line type view in listing page
-- Addressed an issue where using the browser’s back button did not return the customer to previous step during checkout [#0007004](https://bugs.oxid-esales.com/view.php?id=7004)
+- Addressed an issue where using the browser's back button did not return the customer to previous step during checkout [#0007004](https://bugs.oxid-esales.com/view.php?id=7004)
 - Clear inputs and adjust contact form success message design on submit [#0006031](https://bugs.oxid-esales.com/view.php?id=6031)
 - Display minimum order message on every checkout step [#0007637](https://bugs.oxid-esales.com/view.php?id=7637)
 - Explanation marks for downloadable products [#0006917](https://bugs.oxid-esales.com/view.php?id=6917)

--- a/tpl/page/checkout/inc/agb.html.twig
+++ b/tpl/page/checkout/inc/agb.html.twig
@@ -18,10 +18,12 @@
                 {% if oView.isConfirmAGBActive() %}
                     {% ifcontent ident "oxrighttocancellegend" set oContent %}
                         <div class="form-check">
+                            {% block agb_checkbox %}
                             <input id="checkAgbTop" class="form-check-input" type="checkbox" name="ord_agb" value="1">
                             <label for="checkAgbTop" class="form-check-label">
                                  {{ include(template_from_string(oContent.oxcontents__oxcontent.value)) | sanitize_html }}
                             </label>
+                            {% endblock %}
                         </div>
                     {% endifcontent %}
                 {% else %}


### PR DESCRIPTION
Some of the payment modules need to adjust arguments in the checkbox input to map it to JS code. Instead of overriding whole agb template, we can use a block.