### PR TITLE
Fix broken WebP picture element in product grid listing

### DIFF
--- a/tpl/widget/product/listitem_grid.html.twig
+++ b/tpl/widget/product/listitem_grid.html.twig
@@ -27,7 +27,7 @@
         <div class="product-img-wrapper">
 
             <img {% if slider %}loading="lazy" {% endif %}width="350" height="220" src="{{ product.getThumbnailUrl()|raw }}" alt="{{ translate({ ident: "PRODUCT_SINGLE_IMAGE_ALT", args: product.oxarticles__oxtitle.value ~ ' ' ~ product.oxarticles__oxvarselect.value }) }}" class="product-img">
-            {% if product.getPictureUrl(2) %}
+            {% if product.getMasterZoomPictureUrl(2) %}
                 <img class="product-img img-2 d-none d-lg-block" width="350" height="220" loading="lazy" src="{{ product.getPictureUrl(2)|raw }}" alt="{{ translate({ ident: "PRODUCT_SINGLE_IMAGE_ALT", args: product.oxarticles__oxtitle.value ~ ' ' ~ product.oxarticles__oxvarselect.value }) }}">
             {% endif %}
             <a href="{{ _productLink|raw }}" class="stretched-link" aria-label="{{ translate({ ident: "DETAILS" }) }} - {{ product.oxarticles__oxtitle.value }}"></a>

--- a/tpl/widget/product/listitem_grid.html.twig
+++ b/tpl/widget/product/listitem_grid.html.twig
@@ -27,11 +27,8 @@
         <div class="product-img-wrapper">
 
             <img {% if slider %}loading="lazy" {% endif %}width="350" height="220" src="{{ product.getThumbnailUrl()|raw }}" alt="{{ translate({ ident: "PRODUCT_SINGLE_IMAGE_ALT", args: product.oxarticles__oxtitle.value ~ ' ' ~ product.oxarticles__oxvarselect.value }) }}" class="product-img">
-            {% if product.getMasterZoomPictureUrl(2) %}
-                <picture>
-                    <source type="image/webp" srcset="{{ product.getMasterZoomPictureUrl(2)|raw }}" media="(min-width: 1024px)">
-                    <img class="product-img img-2" width="350" height="220" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" alt="{{ translate({ ident: "PRODUCT_SINGLE_IMAGE_ALT", args: product.oxarticles__oxtitle.value ~ ' ' ~ product.oxarticles__oxvarselect.value }) }}">
-                </picture>
+            {% if product.getPictureUrl(2) %}
+                <img class="product-img img-2 d-none d-lg-block" width="350" height="220" loading="lazy" src="{{ product.getPictureUrl(2)|raw }}" alt="{{ translate({ ident: "PRODUCT_SINGLE_IMAGE_ALT", args: product.oxarticles__oxtitle.value ~ ' ' ~ product.oxarticles__oxvarselect.value }) }}">
             {% endif %}
             <a href="{{ _productLink|raw }}" class="stretched-link" aria-label="{{ translate({ ident: "DETAILS" }) }} - {{ product.oxarticles__oxtitle.value }}"></a>
 


### PR DESCRIPTION
## Summary

- The `<picture>` element in `listitem_grid.html.twig` incorrectly declared `type="image/webp"` while `getMasterZoomPictureUrl(2)` returned a PNG/JPG master URL that bypasses `PictureHandler` and its WebP URL logic entirely
- The fallback `<img>` was a transparent 1x1 GIF, rendering nothing on mobile viewports (< 1024px)
- Master images were served at original resolution into a 350x220 container, wasting bandwidth

Replaced with a simple `<img>` using `getPictureUrl(2)` which correctly routes through `PictureHandler::getProductPicUrl()`, serving scaled images from `/generated/` with proper `.webp` suffix when `blConvertImagesToWebP` is enabled. Desktop-only visibility is handled via Bootstrap's `d-none d-lg-block` instead of the broken `media` query approach.

Note: This is a backport-style fix for OXID 7.x. The same issue was addressed differently on `b-8.0.x` via OXDEV-9008 using the new `MediaItem` API.

## Test plan

- [ ] Verify hover image still appears on desktop in category grid view
- [ ] Inspect HTML: no `type="image/webp"`, URL should point to `/out/pictures/generated/` (not `/master/`)
- [ ] With `blConvertImagesToWebP` enabled: URL should end in `.webp`
- [ ] On mobile viewport: no invisible/broken image element from the hover picture