### PR TITLE
Use WebP-aware image methods in product detail gallery

### DIFF
--- a/tpl/page/details/inc/gallery/zoom/product_hover_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_hover_zoom.html.twig
@@ -6,7 +6,7 @@
         {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
 
         <figure class="zoom-container-hover">
-            <img src="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
+            <img src="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
         </figure>
     {% endfor %}
 </div>

--- a/tpl/page/details/inc/gallery/zoom/product_hover_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_hover_zoom.html.twig
@@ -2,9 +2,6 @@
 
 <div class="wrap">
     {% for iPicNr, oArtIcon in oView.getIcons() %}
-        {% set sPictureName = oPictureProduct.getPictureFieldValue("oxpic", iPicNr) %}
-        {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
-
         <figure class="zoom-container-hover">
             <img src="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
         </figure>

--- a/tpl/page/details/inc/gallery/zoom/product_magnifier_lens.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_magnifier_lens.html.twig
@@ -2,9 +2,6 @@
 
 <div class="wrap slider-container overflow-visible">
     {% for iPicNr, oArtIcon in oView.getIcons() %}
-        {% set sPictureName = oPictureProduct.getPictureFieldValue('oxpic', iPicNr) %}
-        {% set aPictureInfo = config.getMasterPicturePath('product/' ~ iPicNr ~ '/' ~ sPictureName)|getimagesize %}
-
         <figure class="zoom-container-magnifier">
             <img src="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
             <div class="lens"></div>

--- a/tpl/page/details/inc/gallery/zoom/product_magnifier_lens.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_magnifier_lens.html.twig
@@ -6,7 +6,7 @@
         {% set aPictureInfo = config.getMasterPicturePath('product/' ~ iPicNr ~ '/' ~ sPictureName)|getimagesize %}
 
         <figure class="zoom-container-magnifier">
-            <img src="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
+            <img src="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
             <div class="lens"></div>
             <div class="zoom-result-magnifier">
                 <img src="" alt="Magnified image">

--- a/tpl/page/details/inc/gallery/zoom/product_modal_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_modal_zoom.html.twig
@@ -6,7 +6,7 @@
     {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
 
     <figure class="zoom-container" data-bs-target="#carouselZoomPicturesIndicators" data-bs-slide-to="{{ loop.index - 1 }}">
-        <img src="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}" data-bs-toggle="modal" data-bs-target="#zoomModal" />
+        <img src="{{ oPictureProduct.getPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}" data-bs-toggle="modal" data-bs-target="#zoomModal" />
     </figure>
 {% endfor %}
 </div>
@@ -27,7 +27,7 @@
                         {% for iPicNr, oArtIcon in oView.getIcons() %}
                             <div class="carousel-item h-100{% if loop.index == 1 %} active{% endif %}">
                                 <img
-                                    src="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}"
+                                    src="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}"
                                     class="d-block mx-auto object-fit-contain w-100 h-100"
                                     alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}">
                             </div>

--- a/tpl/page/details/inc/gallery/zoom/product_modal_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_modal_zoom.html.twig
@@ -2,9 +2,6 @@
 
 <div class="wrap">
 {% for iPicNr, oArtIcon in oView.getIcons() %}
-    {% set sPictureName = oPictureProduct.getPictureFieldValue("oxpic", iPicNr) %}
-    {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
-
     <figure class="zoom-container" data-bs-target="#carouselZoomPicturesIndicators" data-bs-slide-to="{{ loop.index - 1 }}">
         <img src="{{ oPictureProduct.getPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}" data-bs-toggle="modal" data-bs-target="#zoomModal" />
     </figure>

--- a/tpl/page/details/inc/gallery/zoom/product_no_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_no_zoom.html.twig
@@ -1,8 +1,5 @@
 <div class="wrap">
     {% for iPicNr, oArtIcon in oView.getIcons() %}
-        {% set sPictureName = oPictureProduct.getPictureFieldValue("oxpic", iPicNr) %}
-        {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
-
         <figure>
             <img src="{{ oPictureProduct.getPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}"/>
         </figure>

--- a/tpl/page/details/inc/gallery/zoom/product_no_zoom.html.twig
+++ b/tpl/page/details/inc/gallery/zoom/product_no_zoom.html.twig
@@ -4,7 +4,7 @@
         {% set aPictureInfo = config.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
 
         <figure>
-            <img src="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}"/>
+            <img src="{{ oPictureProduct.getPictureUrl(iPicNr)|raw }}" alt="{{ translate({ ident: "PRODUCT_GALLERY_IMAGE_ALT", args: { "count": iPicNr, "title": oPictureProduct.oxarticles__oxtitle.value|striptags ~ ' ' ~ oPictureProduct.oxarticles__oxvarselect.value|striptags } }) }}"/>
         </figure>
     {% endfor %}
 </div>

--- a/tpl/page/details/inc/morepics.html.twig
+++ b/tpl/page/details/inc/morepics.html.twig
@@ -7,7 +7,7 @@
                 {% set sPictureName = oPictureProduct.getPictureFieldValue("oxpic", iPicNr) %}
                 {% set aPictureInfo = oPictureProduct.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
                 <li class="details-picture-more-list-item">
-                    <a id="morePics_{{ loop.index }}"{% if aPictureInfo %} data-width="{{ aPictureInfo.0 }}" data-height="{{ aPictureInfo.1 }}"{% endif %} data-zoom-url="{{ oPictureProduct.getMasterZoomPictureUrl(iPicNr)|raw }}">
+                    <a id="morePics_{{ loop.index }}"{% if aPictureInfo %} data-width="{{ aPictureInfo.0 }}" data-height="{{ aPictureInfo.1 }}"{% endif %} data-zoom-url="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}">
                         <img class="details-picture-more-img" src="{{ oPictureProduct.getIconUrl(iPicNr)|raw }}" alt="morepic-{{ loop.index }}">
                     </a>
                 </li>

--- a/tpl/page/details/inc/morepics.html.twig
+++ b/tpl/page/details/inc/morepics.html.twig
@@ -4,10 +4,8 @@
     <div class="details-picture-more{% if iMorePics > 4 %} flexslider{% endif %}" id="morePicsContainer">
         <ul class="{% if iMorePics > 4 %}slides{% else %}details-picture-more-list{% endif %}">
             {% for iPicNr, oArtIcon in oView.getIcons() %}
-                {% set sPictureName = oPictureProduct.getPictureFieldValue("oxpic", iPicNr) %}
-                {% set aPictureInfo = oPictureProduct.getMasterPicturePath("product/" ~ iPicNr ~ "/" ~ sPictureName)|getimagesize %}
                 <li class="details-picture-more-list-item">
-                    <a id="morePics_{{ loop.index }}"{% if aPictureInfo %} data-width="{{ aPictureInfo.0 }}" data-height="{{ aPictureInfo.1 }}"{% endif %} data-zoom-url="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}">
+                    <a id="morePics_{{ loop.index }}" data-zoom-url="{{ oPictureProduct.getZoomPictureUrl(iPicNr)|raw }}">
                         <img class="details-picture-more-img" src="{{ oPictureProduct.getIconUrl(iPicNr)|raw }}" alt="morepic-{{ loop.index }}">
                     </a>
                 </li>


### PR DESCRIPTION
## Summary

- All gallery zoom templates and morepics used `getMasterZoomPictureUrl()` which calls `Config::getPictureUrl()` directly, bypassing `PictureHandler` and its WebP URL logic
- This served unscaled master images (original resolution PNG/JPG) without WebP conversion, even when `blConvertImagesToWebP` is enabled
- Master images are served directly by Apache without going through `getimg.php`

Replaced with the appropriate WebP-aware methods that route through `PictureHandler::getProductPicUrl()`:

| Template | Before | After | Rationale |
|----------|--------|-------|-----------|
| `product_no_zoom` | `getMasterZoomPictureUrl` | `getPictureUrl` | Display only, no zoom |
| `product_hover_zoom` | `getMasterZoomPictureUrl` | `getZoomPictureUrl` | JS zooms via CSS transform on same img |
| `product_magnifier_lens` | `getMasterZoomPictureUrl` | `getZoomPictureUrl` | JS copies img.src to magnifier result |
| `product_modal_zoom` (slider) | `getMasterZoomPictureUrl` | `getPictureUrl` | Preview before opening modal |
| `product_modal_zoom` (modal) | `getMasterZoomPictureUrl` | `getZoomPictureUrl` | Enlarged view inside modal |
| `morepics` (data-zoom-url) | `getMasterZoomPictureUrl` | `getZoomPictureUrl` | Zoom URL for JS |

Note: `getZoomPictureUrl()` already existed in Article.php but was unused by any template. It uses the configurable `sZoomImageSize` parameter and is fully WebP-aware.

Related: OXDEV-9008 solved this differently on b-8.0.x via a new MediaItem API.

## Test plan

- [ ] Product detail page: main image loads from `/generated/` (not `/master/`)
- [ ] With `blConvertImagesToWebP` enabled: image URLs end in `.webp`
- [ ] No zoom (`productZoomType` unset): product image displays correctly
- [ ] Hover zoom: zoom effect works on mouseover
- [ ] Magnifier lens: lens and result display correctly
- [ ] Modal zoom: click opens modal, carousel works, images are larger resolution
- [ ] Morepics: clicking thumbnails switches the main image
- [ ] Image sizes match configured `aDetailImageSizes` / `sZoomImageSize`