### PR TITLE
Fix order history showing 'Shipped' for unshipped orders

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -1,5 +1,10 @@
 # Change Log for OXID APEX Theme
 
+## Unreleased
+
+### Fixed
+- Order history showing "Shipped" status for unshipped orders due to stale empty-date sentinel [PR-72](https://github.com/OXID-eSales/apex-theme/pull/72)
+
 ## v3.1.0 - 2026-04-08
 
 ### Added

--- a/tpl/page/account/order.html.twig
+++ b/tpl/page/account/order.html.twig
@@ -29,7 +29,7 @@
                                     <span id="accOrderStatus_{{ order.oxorder__oxordernr.value }}">
                                             {% if order.oxorder__oxstorno.value %}
                                                 <span class="note">{{ translate({ ident: "ORDER_IS_CANCELED" }) }}</span>
-                                            {% elseif order.oxorder__oxsenddate.value !=" - " %}
+                                            {% elseif order.oxorder__oxsenddate.value|trim not in ["", "-", " - "] %}
                                                 <span>{{ translate({ ident: "SHIPPED" }) }}</span>
                                             {% else %}
                                                 <span class="note">{{ translate({ ident: "NOT_SHIPPED_YET" }) }}</span>


### PR DESCRIPTION
## Problem

In the account order history (`page/account/order.html.twig`), the shipping status check on line 32 compares:

```twig
{% elseif order.oxorder__oxsenddate.value !=" - " %}
```

This comparison expects the formatted empty-date string to be `" - "` (space-dash-space). However, OXID 7.x formats `0000-00-00 00:00:00` as `"-"` (just a dash, no spaces):

```
// Actual formatted value for an unshipped order:
order.oxorder__oxsenddate.value → "-"

// Template compares against:
" - "

// Result: "-" != " - " → true → always shows "Shipped!"
```

**Every order in the history displays "Shipped!" regardless of whether it has actually been shipped.** This includes orders that are still being processed, awaiting payment, or not yet fulfilled.

## Root Cause

The date formatting changed between OXID versions. The old Smarty-era formatting produced `" - "` for empty dates, but the current Twig-based formatting produces `"-"`. The template comparison was never updated to match.

## Fix

Replace the single-value string comparison with a robust check that covers all known empty-date representations:

```twig
{% elseif order.oxorder__oxsenddate.value|trim not in ["", "-", " - "] %}
```

This handles:
- `""` — empty string (e.g. NULL database value)
- `"-"` — current OXID 7.x formatting of `0000-00-00`
- `" - "` — legacy formatting (backward compatible)

The `|trim` filter ensures leading/trailing whitespace doesn't cause further mismatches.

## Scope

The same line exists in `b-7.4.x`, `b-7.5.x`, and `b-8.0.x`. This PR targets `b-7.4.x`; the fix should be cherry-picked to the other branches.

## How to Reproduce

1. Create an order in the shop
2. Do **not** set a shipping date (leave `OXSENDDATE` at `0000-00-00 00:00:00`)
3. Log in as the customer who placed the order
4. Navigate to "My Account" → "Order History"
5. **Expected:** Status shows "Not yet shipped"
6. **Actual:** Status shows "Shipped!"

## How to Verify the Fix

After applying, repeat the steps above. Orders without a shipping date now correctly show "Not yet shipped", while orders with a real `OXSENDDATE` continue to show "Shipped!".