### PR TITLE
Add A–Z brand filter and grid/list toggle to the manufacturer overview

### DIFF
--- a/de/theme_options.php
+++ b/de/theme_options.php
@@ -93,6 +93,8 @@ $aLang = array(
 
     'SHOP_THEME_blShowListDisplayType'              => 'Produktlistentyp in Produktlisten anzeigen',
     'HELP_SHOP_THEME_blShowListDisplayType'         => 'Darf der Besucher Ihres Online-Shops die Art der Listenansicht auswählen? Falls diese Option nicht aktiviert ist, werden die Listenansichten so angezeigt wie in der Dropbox "Standard für Produktlistentyp" eingestellt.',
+    'SHOP_THEME_blBrandAzEnabled'                   => 'A–Z-Markenfilter auf der Hersteller-Übersicht',
+    'HELP_SHOP_THEME_blBrandAzEnabled'              => 'Zeigt auf der Hersteller-Übersichtsseite (Nach Hersteller) eine A–Z-Sprungleiste sowie einen Galerie/Liste-Umschalter an. Ist diese Option deaktiviert, wird die Hersteller-Übersicht wie im Standard dargestellt.',
     'SHOP_THEME_sDefaultListDisplayType'            => 'Standard für Produktlistentyp',
     'SHOP_THEME_sDefaultListDisplayType_grid'       => 'Galerie',
     'SHOP_THEME_sDefaultListDisplayType_line'       => 'Liste',

--- a/en/theme_options.php
+++ b/en/theme_options.php
@@ -93,6 +93,8 @@ $aLang = array(
 
     'SHOP_THEME_blShowListDisplayType'              => 'Display product list type selector',
     'HELP_SHOP_THEME_blShowListDisplayType'         => 'Decide if the visitor of your store can select the type of the product list in store front. If this options is not activated, your visitors will see the lists displayed like you adjusted in the drop box "Default product list type".',
+    'SHOP_THEME_blBrandAzEnabled'                   => 'A–Z brand filter on the manufacturer overview',
+    'HELP_SHOP_THEME_blBrandAzEnabled'              => 'Shows an A–Z jump bar and a grid/list toggle on the manufacturer overview page (By manufacturer). If this option is disabled, the manufacturer overview is displayed the default way.',
     'SHOP_THEME_sDefaultListDisplayType'            => 'Default product list type',
     'SHOP_THEME_sDefaultListDisplayType_grid'       => 'Grid',
     'SHOP_THEME_sDefaultListDisplayType_line'       => 'List',

--- a/theme.php
+++ b/theme.php
@@ -48,6 +48,12 @@ $aTheme = [
         ],
         [
             'group' => 'display',
+            'name'  => 'blBrandAzEnabled',
+            'type'  => 'bool',
+            'value' => 1,
+        ],
+        [
+            'group' => 'display',
             'name'  => 'blShowWeightInList',
             'type'  => 'bool',
             'value' => 1,

--- a/tpl/page/list/list.html.twig
+++ b/tpl/page/list/list.html.twig
@@ -93,7 +93,33 @@
     {% if oView.hasVisibleSubCats() %}
         <div class="container-xxl">
             {% set iSubCategoriesCount = 0 %}
-            <div class="cat-list mb-4 pb-3">
+            {# OPALE-137: Brand A–Z overview — jump filter + grid/line toggle.
+               Scoped to the manufacturer overview only; category/vendor sub-cat
+               grids are untouched. Progressive enhancement: with JS disabled the
+               full brand grid still renders exactly as before. Toggleable via the
+               theme option "blBrandAzEnabled" (default on; unset value = on). #}
+            {% set brandAzOption = oViewConf.getViewThemeParam('blBrandAzEnabled') %}
+            {# On by default; only an explicit boolean false (theme option unticked) disables it.
+               Strict compare so an unset value (null) keeps the feature enabled. #}
+            {% set brandAz = (listType == 'manufacturer') and (brandAzOption is not same as(false)) %}
+            {% if brandAz %}
+                <div class="brand-az mb-3" data-brand-az>
+                    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+                        <nav class="brand-az-index d-flex flex-wrap gap-1" aria-label="{{ translate({ ident: "BRAND" }) }} A–Z" data-brand-az-index></nav>
+                        <div class="btn-group mb-auto brand-az-view" role="group" aria-label="{{ translate({ ident: "BRAND" }) }}">
+                            <button type="button" class="btn btn-primary btn-icon" data-brand-az-view="grid" aria-pressed="true" title="{{ translate({ ident: "grid" }) }}">
+                                <svg><use xlink:href="#grid-fill"></use></svg>
+                                <span class="visually-hidden">{{ translate({ ident: "grid" }) }}</span>
+                            </button>
+                            <button type="button" class="btn btn-outline-primary btn-icon" data-brand-az-view="line" aria-pressed="false" title="{{ translate({ ident: "line" }) }}">
+                                <svg><use xlink:href="#list-ul"></use></svg>
+                                <span class="visually-hidden">{{ translate({ ident: "line" }) }}</span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            <div class="cat-list mb-4 pb-3{% if brandAz %} brand-az-list{% endif %}"{% if brandAz %} data-brand-az-list{% endif %}>
                 {% for category in oView.getSubCatList() %}
                     {% if category.getIsVisible() %}
                         {% set iSubCategoriesCount = iSubCategoriesCount+1 %}
@@ -103,7 +129,11 @@
                         {% else %}
                             {% set iconAltAttribute = translate({ ident: "CATEGORY_IMAGE_ALT", args: category.oxcategories__oxtitle.value }) %}
                         {% endif %}
-                            <a href="{{ category.getLink()|raw }}" title="{{ category.oxcategories__oxdesc.value }}" class="cat-list-item">
+                        {% if brandAz %}
+                            {% set brandFirst = (category.oxcategories__oxtitle.value|trim|upper|replace({'Ä':'A','Ö':'O','Ü':'U','ß':'S','Á':'A','À':'A','Â':'A','Ã':'A','Å':'A','Æ':'A','É':'E','È':'E','Ê':'E','Ë':'E','Í':'I','Ì':'I','Î':'I','Ï':'I','Ó':'O','Ò':'O','Ô':'O','Õ':'O','Ø':'O','Ú':'U','Ù':'U','Û':'U','Ñ':'N','Ç':'C'})|first) %}
+                            {% set brandLetter = brandFirst matches '/^[A-Z]$/' ? brandFirst : '#' %}
+                        {% endif %}
+                            <a href="{{ category.getLink()|raw }}" title="{{ category.oxcategories__oxdesc.value }}" class="cat-list-item"{% if brandAz %} data-brand-letter="{{ brandLetter }}"{% endif %}>
                                 {% if iconUrl %}
                                     <img loading="lazy" src="{{ category.getIconUrl()|raw }}" alt="{{ iconAltAttribute }}" class="cat-list-item-img">
                                 {% else %}
@@ -136,6 +166,78 @@
                     {% endif %}
                 {% endfor %}
             </div>
+            {% if brandAz %}
+                <style>
+                    [data-brand-az] .brand-az-index .brand-az-letter { min-width: 2.25rem; text-align: center; }
+                    [data-brand-az] .brand-az-index .brand-az-letter.disabled { opacity: .4; pointer-events: none; }
+                    [data-brand-az-list] .cat-list-item[data-brand-letter] { scroll-margin-top: 6rem; }
+                    [data-brand-az-list].brand-az-list--line { display: block; }
+                    [data-brand-az-list].brand-az-list--line .cat-list-item { display: flex; align-items: center; gap: .75rem; width: 100%; max-width: none; padding: .5rem .25rem; border-bottom: 1px solid var(--bs-border-color); }
+                    [data-brand-az-list].brand-az-list--line .cat-list-item-img { width: 2.5rem; height: 2.5rem; object-fit: contain; flex: 0 0 auto; }
+                    [data-brand-az-list].brand-az-list--line .cat-list-item-name { text-align: left; }
+                </style>
+                <script>
+                    (function () {
+                        var root = document.querySelector('[data-brand-az]');
+                        var list = document.querySelector('[data-brand-az-list]');
+                        if (!root || !list) { return; }
+
+                        var ORDER = ['#','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z'];
+                        var items = Array.prototype.slice.call(list.querySelectorAll('.cat-list-item[data-brand-letter]'));
+                        var firstOf = {};
+                        items.forEach(function (item) {
+                            var l = item.getAttribute('data-brand-letter') || '#';
+                            if (!firstOf[l]) {
+                                firstOf[l] = item;
+                                item.id = 'brand-letter-' + (l === '#' ? 'num' : l);
+                            }
+                        });
+
+                        var nav = root.querySelector('[data-brand-az-index]');
+                        if (nav) {
+                            ORDER.forEach(function (l) {
+                                var present = !!firstOf[l];
+                                var el = document.createElement(present ? 'a' : 'span');
+                                el.className = 'btn btn-sm brand-az-letter ' + (present ? 'btn-outline-primary' : 'btn-outline-secondary disabled');
+                                el.textContent = (l === '#') ? '0–9' : l;
+                                if (present) {
+                                    el.href = '#' + firstOf[l].id;
+                                    el.addEventListener('click', function (e) {
+                                        e.preventDefault();
+                                        firstOf[l].scrollIntoView({ behavior: 'smooth', block: 'start' });
+                                        if (history.replaceState) { history.replaceState(null, '', '#' + firstOf[l].id); }
+                                    });
+                                } else {
+                                    el.setAttribute('aria-disabled', 'true');
+                                }
+                                nav.appendChild(el);
+                            });
+                        }
+
+                        var KEY = 'opalBrandAzView';
+                        var buttons = Array.prototype.slice.call(root.querySelectorAll('[data-brand-az-view]'));
+                        function apply(view) {
+                            list.classList.toggle('brand-az-list--line', view === 'line');
+                            buttons.forEach(function (b) {
+                                var active = b.getAttribute('data-brand-az-view') === view;
+                                b.classList.toggle('btn-primary', active);
+                                b.classList.toggle('btn-outline-primary', !active);
+                                b.setAttribute('aria-pressed', active ? 'true' : 'false');
+                            });
+                        }
+                        buttons.forEach(function (b) {
+                            b.addEventListener('click', function () {
+                                var view = b.getAttribute('data-brand-az-view');
+                                try { localStorage.setItem(KEY, view); } catch (e) {}
+                                apply(view);
+                            });
+                        });
+                        var saved = null;
+                        try { saved = localStorage.getItem(KEY); } catch (e) {}
+                        apply(saved === 'line' ? 'line' : 'grid');
+                    }());
+                </script>
+            {% endif %}
         </div>
     {% endif %}
 


### PR DESCRIPTION
## What
Adds an **A–Z brand filter** and a **grid/list view toggle** to the manufacturer overview page ("By manufacturer", `cl=manufacturerlist` root), plus a theme option to enable/disable it.

## Why
The manufacturer overview currently renders only a flat alphabetical grid of all manufacturers. On shops with many brands that is hard to navigate; an A–Z brand directory is a common feature on other platforms (Shopware, Magento, WooCommerce).

## Changes
- **`tpl/page/list/list.html.twig`** — within the existing `hasVisibleSubCats` block, gated to `listType == 'manufacturer'`:
  - A–Z jump bar (`0–9`, `A`–`Z`); present letters link to the first brand of that letter (smooth scroll), missing letters are disabled. First letters are folded (Ä→A, Ö→O, Ü→U, accents, ß→S).
  - grid/list toggle (`btn-primary` active / `btn-outline-primary` inactive), preference kept in `localStorage`.
  - Progressive enhancement: brand letters are emitted as a `data-brand-letter` attribute; the index/anchor/toggle logic is a small inline script. With JS disabled the existing grid renders unchanged.
- **`theme.php`** — new `bool` option `blBrandAzEnabled` (group `display`, default on).
- **`de/theme_options.php`, `en/theme_options.php`** — label + help text for the option.

## Scope / safety
- Strictly gated to the manufacturer overview; category and vendor listings that share this template are unaffected.
- Theme-aware: Bootstrap classes / CSS variables (`--bs-border-color`), no hardcoded colors (dark mode safe).
- Product counts render as before (core, subject to `blPerfShowActionCatArticleCnt`) — unchanged.

## Testing
Verified on OXID 7.5.1 / apex 3.1.0:
- A–Z bar enables only present letters (folding verified), jump anchors correct.
- grid ↔ list toggle switches layout and persists; active state clearly highlighted.
- category and vendor lists unchanged (no A–Z bar); no console errors.
- theme option **off** → plain core grid; **on** → feature returns; option visible under Admin → Themes → APEX → Settings (Display group).

## Note
New theme options are registered in `oxconfigdisplay` on theme (re)activation. On a fresh install this happens automatically; an already-active theme has to be re-activated once for the option to appear in the admin.

_Origin: internal OPALE-137._
